### PR TITLE
feat(khalti): added Request and response based payment verification m…

### DIFF
--- a/nepali_wallets/client/_khalti.py
+++ b/nepali_wallets/client/_khalti.py
@@ -59,8 +59,18 @@ class KhaltiClient(BasePaymentClient):
         print("payment completion is automatically handled by the khalti client itself")
         raise NotImplementedError()
 
-    def verify_payment(self, token: str):
-        raise NotImplementedError()
+    def verify_payment(self, intent: Union[KhaltiIntent, str]):
+        if isinstance(intent, KhaltiIntent):
+            intent = intent.id
+        return self.session.post(
+            f'{self.base_url}/epayment/lookup/',
+            data=json.dumps(
+                {
+                    'pidx': intent
+                }
+            ),
+            headers=self._get_request_headers()
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/clients/test_khalti.py
+++ b/tests/clients/test_khalti.py
@@ -16,18 +16,30 @@ class TestKhalti:
             }
         )
         assert intent.id is not None
+        assert 'pidx' in intent.data
 
-    def test_khalti_intent__duplicate_order(self):
-        current_timestamp = datetime.now().timestamp()
-        data = {
-            'amount': 1000,
-            'order_id': f'test_order_{current_timestamp}',
-            'order_name': f"Test Order {current_timestamp}",
-            'customer_info': {
-                'name': 'John Doe',
-                'email': 'johndoe@example.com',
-            }
-        }
-        khalti_client.create_intent(**data)
-        intent = khalti_client.create_intent(**data)
-        assert intent.id is None
+    def test_khalti_intent__status(self, khalti__intent):
+        print(khalti__intent.id)
+        data = khalti_client.verify_payment(khalti__intent)
+        print(data.text)
+
+    def test_khalti__payment(self, khalti__intent):
+        """
+        To run this test case, you must provide -s argument since this test case needs user interaction
+
+        example 1: pytest -s
+        example 2: pytest -s -k khalti__payment
+
+        Once this test starts, the payment intent is created, at the time, you need to click the link generated
+        by khalti and complete payment with credentials as follows:
+
+        phone: 9800000000 / 9800000001 ... 9800000005
+        mpin: 1111
+        OTP: 987654
+        """
+        print(khalti__intent.data)
+        print("Click the link, pay and continue")
+        intent = input(f'intent id [{khalti__intent.id}]: ')
+        data = khalti_client.verify_payment(intent or khalti__intent)
+        assert data.json()['status'] == 'Completed'
+

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,13 +4,14 @@ from .connectors import khalti_client
 from datetime import datetime
 
 __all__ = [
-    'intent__khalti',
+    'khalti__intent',
 ]
 
+
 @pytest.fixture
-def intent__khalti():
+def khalti__intent():
     current_timestamp = datetime.now().timestamp()
-    intent_response = khalti_client.create_intent(
+    intent = khalti_client.create_intent(
         amount=1000,
         order_id=f'order_{current_timestamp}',
         order_name="Test Order",
@@ -19,4 +20,4 @@ def intent__khalti():
             'email': 'abc@email.com',
         }
     )
-    return intent_response
+    return intent


### PR DESCRIPTION
## Khalti Payment Verification

To run the test case, you must provide `-s` argument since this test case needs user interaction

example 1: `pytest -s`
example 2: `pytest -s -k khalti__payment`

Once this test starts, the payment intent is created, at the time, you need to click the link generated
by khalti and complete payment with credentials as follows:

phone: `9800000000` / `9800000001` ... `9800000005`
mpin: `1111`
OTP: `987654`